### PR TITLE
Feature: Higher-level COFF relocations API

### DIFF
--- a/epep_cli.c
+++ b/epep_cli.c
@@ -346,9 +346,14 @@ int main(int argc, char **argv) {
 			} else {
 				printf(" (%.*s)\n", 8, sh.Name);
 			}
-			for (size_t i = 0; i < sh.NumberOfRelocations; i++) {
+			size_t number_of_relocations;
+			int extended;
+			if (!epep_get_section_number_of_relocations_x(&epep, &sh, &number_of_relocations, &extended)) {
+				return ERROR(epep);
+			}
+			for (size_t i = 0; i < number_of_relocations; i++) {
 				EpepCoffRelocation rel = { 0 };
-				if (!epep_get_section_relocation_by_index(&epep, &sh, &rel, i)) {
+				if (!epep_get_section_relocation_by_index_x(&epep, &sh, &rel, i, extended)) {
 					return ERROR(epep);
 				}
 				printf("    COFF Relocation #%u\n", i);


### PR DESCRIPTION
Number of COFF relocations of a section is stored in the 16-bit `NumberOfRelocations` field of a section header. If a COFF object has more than 2^16 - 1 relocations, then the value does not fit in the field.

To solve this problem, `IMAGE_SCN_LNK_NRELOC_OVFL` flag of a section header has been introduced. If this flag is set for the section, then the actual number of relocations is stored in the `VirtualAddress` field of the first relocation.

If the flag is set, then `NumberOfRelocations` field of the section header should be equal to `0xffff`, othervice the linker should give an error.

So this patch introduces few functions adressing this mechanism.

1. `epep_section_contains_extended_relocations`
   
   Checks whether the section has more than 2^16 - 1 relocations. Retrns error if the `IMAGE_SCN_LNK_NRELOC_OVFL` flag is set, but the `NumberOfRelocations` field is not equal to `0xffff`.

2. `epep_get_section_extended_number_of_relocations`
   
   Reads the number of COFF relocations from the `VirtualAddress` field of the first COFF relocation.

3. `epep_get_section_number_of_relocations_x`
   
   Gives the number of meaningful relocations of the section.
   
   If the section has less than 2^16 relocations, then returns the value of the `NumberOfRelocations` field of the section header, othervice reads the number of relocations from the first COFF relocation, but: since the first relocation in this case is not meaningful, gives the actual number of relocations minus one. This is used in the function documented below.
   
   Returns 1 in the last argument if the section contains extended number of relocations, 0 othervice.

5. `epep_get_section_relocation_by_index_x`

   If the section has less than 2^16 relocations, then just reads a relocation by the given index. In case if the section has extended number of relocations, the first relocation is not meaningful, so it is skipped, and the relocation at index + 1 is read instead.

Fixed epep_cli to use this API and added and fixed a few comments by the way.